### PR TITLE
fix: Gives the proper weight to the different versions in age

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,6 @@ jobs:
         uses: actions/checkout@v2
       - name: asdf_install
         uses: asdf-vm/actions/install@v1
-        with:
-          before_install: bash -c '${ASDF_DATA_DIR:=$HOME/.asdf}/plugins/nodejs/bin/import-release-team-keyring'
       - name: Shellcheck
         run: shellcheck -x bin/* -P lib/
       - name: Shell Format - List files to check

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,2 @@
 shellcheck 0.7.1
 shfmt 3.2.2
-nodejs 14.2.0

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+SHFMT_BASE_FLAGS = -s -i 2 -ci
+SHELLCHECK_FLAGS = -x bin/* -P lib/
+
+fmt:
+	shfmt -w $(SHFMT_BASE_FLAGS) .
+.PHONY: fmt
+
+fmt-check:
+	shfmt -d $(SHFMT_BASE_FLAGS) .
+.PHONY: fmt-check
+
+lint:
+	shellcheck $(SHELLCHECK_FLAGS)
+.PHONY: lint

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -14,14 +14,13 @@ fail() {
 
 curl_opts=(-fsSL)
 
-# NOTE: You might want to remove this if age is not hosted on GitHub releases.
 if [ -n "${GITHUB_API_TOKEN:-}" ]; then
   curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
 fi
 
 sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+    awk 'BEGIN{ FS="-" } { if ($0 ~ /beta/) {print $1" 1 "$0} else if ($0 ~ /rc/) { print $1" 2 "$0 } else { print $1" 3 "$0 } }' |
+    LC_ALL=C sort --reverse | awk '{print $3}'
 }
 
 list_github_tags() {
@@ -38,7 +37,7 @@ latest_version() {
   local query
   query="$1"
   [ -z "$query" ] && query="[0-9]"
-  list_all_versions | sort_versions | grep "$query" | tail -n 1
+  list_all_versions | sort_versions | grep "$query" | head -n 1
 }
 
 download_release() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -19,7 +19,7 @@ if [ -n "${GITHUB_API_TOKEN:-}" ]; then
 fi
 
 sort_versions() {
-    awk 'BEGIN{ FS="-" } { if ($0 ~ /beta/) {print $1" 1 "$0} else if ($0 ~ /rc/) { print $1" 2 "$0 } else { print $1" 3 "$0 } }' |
+  awk 'BEGIN{ FS="-" } { if ($0 ~ /beta/) {print $1" 1 "$0} else if ($0 ~ /rc/) { print $1" 2 "$0 } else { print $1" 3 "$0 } }' |
     LC_ALL=C sort --reverse | awk '{print $3}'
 }
 


### PR DESCRIPTION
`age` has two different version modifiers on top of the version number. They rank the following way in regards of priority:

1. No modifier.
2. `rc`
3. `beta`

With the release of the latest major version, the sort algorithm was not properly weighting these modifiers. This patch fixes the order, giving the following priority:

1. Version number.
2. No modifier > `rc` > `beta`
3. Full version

Fixes #1