### PR TITLE
fix: accept empty argument list for latest_stable

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -35,8 +35,11 @@ list_all_versions() {
 
 latest_version() {
   local query
-  query="$1"
-  [ -z "$query" ] && query="[0-9]"
+  if [ "${#}" = 0 ]; then
+    query="[0-9"]
+  else
+    query="${1}"
+  fi
   list_all_versions | sort_versions | grep "$query" | head -n 1
 }
 


### PR DESCRIPTION
This fixes using this plugin with the mise version manager.

When running `mise upgrade age`, it will error out. It's calling `latest_stable` without any arguments. There's a check if `$1` is empty but there's also `set -u` at the top, aborting the script because of the unbound variable.

Test output:

```shell
$ asdf plugin test age https://github.com/fheinle-mak/asdf-age.git "age --help"
Location of age plugin: /tmp/asdf.dwHZ/plugins/age
Updating age to master
Already on 'master'
Your branch is up to date with 'origin/master'.
* Downloading age release 1.2.0 from https://github.com/FiloSottile/age/releases/download/v1.2.0/age-v1.2.0-linux-amd64.tar.gz
age 1.2.0 installation was successful!
Usage:
    age [--encrypt] (-r RECIPIENT | -R PATH)... [--armor] [-o OUTPUT] [INPUT]
    age [--encrypt] --passphrase [--armor] [-o OUTPUT] [INPUT]
    age --decrypt [-i PATH]... [-o OUTPUT] [INPUT]

#[…] rest of the output omitted
```